### PR TITLE
Add Kartavya Soni portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Kartavya Soni Portfolio
+
+This repository contains a simple personal website showcasing Kartavya Soni's skills and projects. Open `index.html` in a web browser to view the site.

--- a/images/headshot.jpg
+++ b/images/headshot.jpg
@@ -1,0 +1,1 @@
+placeholder headshot image

--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kartavya Soni - Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header id="home">
+        <h1>Kartavya Soni</h1>
+        <p class="tagline">Data Science &amp; AI Enthusiast | MSc @ FAU</p>
+        <img src="images/headshot.jpg" alt="Kartavya Soni Headshot" class="headshot">
+        <div class="contact-links">
+            <a href="mailto:ksoni2024@fau.edu">Email</a>
+            <a href="https://linkedin.com/in/kartavyasoni8">LinkedIn</a>
+            <a href="resume.pdf">Resume</a>
+        </div>
+    </header>
+
+    <section id="about">
+        <h2>About Me</h2>
+        <p>I’m Kartavya Soni, a Computer Science Master’s student at Florida Atlantic University, passionate about AI and Data Science. I specialize in building machine learning models, analytical dashboards, and intelligent systems that drive business outcomes. With experience in predictive modeling, React development, and student leadership, I bring both technical and soft skills to the table.</p>
+    </section>
+
+    <section id="skills">
+        <h2>Skills</h2>
+        <h3>Languages</h3>
+        <ul>
+            <li>Python</li>
+            <li>JavaScript</li>
+            <li>SQL</li>
+            <li>R (basic)</li>
+        </ul>
+        <h3>Frameworks</h3>
+        <ul>
+            <li>Pandas</li>
+            <li>NumPy</li>
+            <li>Scikit-Learn</li>
+            <li>TensorFlow</li>
+            <li>Keras</li>
+            <li>Matplotlib</li>
+            <li>OpenCV</li>
+        </ul>
+        <h3>Tools</h3>
+        <ul>
+            <li>Tableau</li>
+            <li>Power BI</li>
+            <li>Jupyter</li>
+            <li>VS Code</li>
+            <li>Git</li>
+            <li>AWS</li>
+            <li>MySQL</li>
+            <li>Microsoft Office</li>
+        </ul>
+        <h3>Soft Skills</h3>
+        <ul>
+            <li>Communication</li>
+            <li>Leadership</li>
+            <li>Problem-Solving</li>
+            <li>Critical Thinking</li>
+            <li>Teamwork</li>
+            <li>Adaptability</li>
+        </ul>
+    </section>
+
+    <section id="projects">
+        <h2>Projects</h2>
+        <div class="project">
+            <h3>Loan Meter – AI-Driven Loan Approval System</h3>
+            <p><strong>Tools:</strong> Python, Scikit-Learn</p>
+            <p>Built a predictive pipeline with 84% accuracy. Used grid search and feature selection for fairness and performance.</p>
+        </div>
+        <div class="project">
+            <h3>FAA Bird Strike Analytics Dashboard</h3>
+            <p><strong>Tools:</strong> Python, Tableau</p>
+            <p>Analyzed 100K+ bird strike records and created dashboards for seasonal risk visualization.</p>
+        </div>
+        <div class="project">
+            <h3>Amazon Sales Performance Engine</h3>
+            <p><strong>Tools:</strong> Power BI, SQL</p>
+            <p>Performed advanced analytics on 5 years of data. Found a 28% Q4 sales surge and built KPI dashboards.</p>
+        </div>
+    </section>
+
+    <section id="experience">
+        <h2>Experience</h2>
+        <h3>Data Science Intern – Unified Mentor (Jan 2024 – Apr 2024)</h3>
+        <ul>
+            <li>Achieved 95% prediction accuracy on loan defaults</li>
+            <li>Improved risk assessment efficiency by 35%</li>
+            <li>Reduced data processing time by 20% through EDA</li>
+        </ul>
+    </section>
+
+    <section id="leadership">
+        <h2>Leadership</h2>
+        <h3>Student Governor – FAU Broward Campuses (May 2025 – Apr 2026)</h3>
+        <ul>
+            <li>Represent 5,000+ students</li>
+            <li>Lead policy advocacy, event management, and budgeting</li>
+            <li>Implemented a digital feedback system to boost student engagement</li>
+        </ul>
+    </section>
+
+    <section id="certificates">
+        <h2>Certificates</h2>
+        <ul>
+            <li>Machine Learning – Stanford University (Coursera)</li>
+            <li>NumPy Essential Training – LinkedIn Learning</li>
+            <li>Pandas Essential Training – LinkedIn Learning</li>
+        </ul>
+    </section>
+
+    <section id="contact">
+        <h2>Contact</h2>
+        <p>Name: Kartavya Soni</p>
+        <p>Email: <a href="mailto:ksoni2024@fau.edu">ksoni2024@fau.edu</a></p>
+        <p>LinkedIn: <a href="https://linkedin.com/in/kartavyasoni8">linkedin.com/in/kartavyasoni8</a></p>
+        <p>Location: Boca Raton, FL</p>
+    </section>
+</body>
+</html>

--- a/resume.pdf
+++ b/resume.pdf
@@ -1,0 +1,1 @@
+placeholder resume

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,56 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    background-color: #f9f9f9;
+    color: #222;
+}
+
+header {
+    background: linear-gradient(to right, #0f0c29, #302b63, #24243e);
+    color: #fff;
+    text-align: center;
+    padding: 2rem 1rem;
+}
+
+.tagline {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+}
+
+.headshot {
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 1rem;
+}
+
+.contact-links a {
+    margin: 0 0.5rem;
+    color: #00aaff;
+    text-decoration: none;
+}
+
+section {
+    padding: 2rem 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+section h2 {
+    color: #302b63;
+    border-bottom: 2px solid #302b63;
+    padding-bottom: 0.5rem;
+}
+
+.project {
+    margin-bottom: 1.5rem;
+}
+
+@media (min-width: 600px) {
+    body {
+        font-size: 18px;
+    }
+}


### PR DESCRIPTION
## Summary
- create simple HTML site to showcase Kartavya Soni
- add responsive styles
- include placeholder headshot and resume
- add project README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da3450df88330b393cd34a5570f46